### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -5,6 +5,9 @@ on:
   # Runs on git reference deletion (branch or tag)
   delete:
 
+permissions:
+  contents: read
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/deeheber/Danielle-s-Blog/security/code-scanning/1](https://github.com/deeheber/Danielle-s-Blog/security/code-scanning/1)

Add an explicit `permissions` block to the workflow root (applies to all jobs) with least privilege.  
For this workflow, the best non-breaking fix is to set:

- `contents: read`

This preserves functionality (the job uses `DISPATCH_TOKEN` for API calls) while ensuring the implicit `GITHUB_TOKEN` is constrained.  
Edit `.github/workflows/dispatch.yml` near the top-level keys, inserting `permissions` between `on` and `jobs` (or anywhere at root level).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
